### PR TITLE
Added link to OpenToAll's home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1286,7 +1286,7 @@ ICMP
 
 
 ```
-OpenToAll
+[OpenToAll](https://opentoallctf.github.io/)
 ```
 
 


### PR DESCRIPTION
Under the "We are a CTF team which is open to everybody. Who are we? " part of the trivia I have changed the already existing "OpenToAll" to link to OpenToAll's main page that has more info (https://opentoallctf.github.io/)