### PR TITLE
Added link to OpenToAll's page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1286,7 +1286,7 @@ ICMP
 
 
 ```
-OpenToAll
+[OpenToAll](https://opentoallctf.github.io/)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1283,12 +1283,11 @@ ICMP
 
 
 *  We are a CTF team which is open to everybody. Who are we?    
-```
-[```link```](http://example.com "Title")
 
 
 ```
-[link](http://example.com "Title")
+OpenToAll - https://opentoallctf.github.io/
+```
 
 
 [steghide]: http://steghide.sourceforge.net/

--- a/README.md
+++ b/README.md
@@ -1286,7 +1286,7 @@ ICMP
 
 
 ```
-.[OpenToAll]:(https://opentoallctf.github.io/)
+[OpenToAll]: https://opentoallctf.github.io/
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1286,7 +1286,7 @@ ICMP
 
 
 ```
-.[OpenToAll](https://opentoallctf.github.io/)
+.[OpenToAll]:(https://opentoallctf.github.io/)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1283,14 +1283,14 @@ ICMP
 
 
 *  We are a CTF team which is open to everybody. Who are we?    
+```
+[```link```](http://example.com "Title")
 
-[link](http://example.com "Title")
+
 ```
 [link](http://example.com "Title")
-[link](http://example.com "Title")
-```
 
-[link](http://example.com "Title")
+
 [steghide]: http://steghide.sourceforge.net/
 [snow]: http://www.darkside.com.au/snow/
 [cribdrag.py]: https://github.com/SpiderLabs/cribdrag

--- a/README.md
+++ b/README.md
@@ -1284,12 +1284,13 @@ ICMP
 
 *  We are a CTF team which is open to everybody. Who are we?    
 
-
+[link](http://example.com "Title")
 ```
+[link](http://example.com "Title")
 [link](http://example.com "Title")
 ```
 
-
+[link](http://example.com "Title")
 [steghide]: http://steghide.sourceforge.net/
 [snow]: http://www.darkside.com.au/snow/
 [cribdrag.py]: https://github.com/SpiderLabs/cribdrag

--- a/README.md
+++ b/README.md
@@ -1286,7 +1286,7 @@ ICMP
 
 
 ```
-[`OpenToAll`](https://opentoallctf.github.io/)
+[link](http://example.com "Title")
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1286,7 +1286,7 @@ ICMP
 
 
 ```
-[OpenToAll](https://opentoallctf.github.io/)
+.[OpenToAll](https://opentoallctf.github.io/)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1286,7 +1286,7 @@ ICMP
 
 
 ```
-[OpenToAll]: https://opentoallctf.github.io/
+[`OpenToAll`](https://opentoallctf.github.io/)
 ```
 
 


### PR DESCRIPTION
Under the "We are a CTF team which is open to everybody. Who are we? " part of the trivia I have changed the already existing "OpenToAll" to link to OpenToAll's main page that has more info (https://opentoallctf.github.io/)